### PR TITLE
Revert "falcon: Fix reverse stereo on speakers/earphones"

### DIFF
--- a/configs/mixer_paths.xml
+++ b/configs/mixer_paths.xml
@@ -363,8 +363,8 @@
 		<ctl name="SLIM RX1 MUX" value="AIF1_PB" />
 		<ctl name="SLIM RX2 MUX" value="AIF1_PB" />
 		<ctl name="SLIM_0_RX Channels" value="Two" />
-		<ctl name="RX1 MIX1 INP1" value="RX1" />
-		<ctl name="RX2 MIX1 INP1" value="RX2" />
+		<ctl name="RX1 MIX1 INP1" value="RX2" />
+		<ctl name="RX2 MIX1 INP1" value="RX1" />
 		<ctl name="CLASS_H_DSM MUX" value="RX_HPHL" />
 		<ctl name="RDAC3 MUX" value="DEM2" />
 		<ctl name="HPHL DAC Switch" value="1" />
@@ -420,8 +420,8 @@
 		<ctl name="SLIM RX1 MUX" value="AIF1_PB" />
 		<ctl name="SLIM RX2 MUX" value="AIF1_PB" />
 		<ctl name="SLIM_0_RX Channels" value="Two" />
-		<ctl name="RX1 MIX1 INP1" value="RX1" />
-		<ctl name="RX2 MIX1 INP1" value="RX2" />
+		<ctl name="RX1 MIX1 INP1" value="RX2" />
+		<ctl name="RX2 MIX1 INP1" value="RX1" />
 		<ctl name="CLASS_H_DSM MUX" value="RX_HPHL" />
 		<ctl name="RDAC3 MUX" value="DEM2" />
 		<ctl name="HPHL DAC Switch" value="1" />


### PR DESCRIPTION
The previous fix was just temporary; a soft reboot causes the problem to occur again until a hard reboot is done. (adjusments have to be made in the audio HAL itself?)
