### PR TITLE
Enable DozeService (Ambient Display) for falcon

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -23,5 +23,15 @@
 
     <!-- Is the device LTE capable -->
     <bool name="config_lte_capable">false</bool>
+    
+    <!-- Enable Doze Service -->
+
+    <bool name="doze_display_state_supported">true</bool>
+    <string name="config_dozeComponent">com.android.systemui/com.android.systemui.doze.DozeService</string>
+    <bool name="config_dozeAfterScreenOff">true</bool>
+    <bool name="config_powerDecoupleInteractiveModeFromDisplay">true</bool>
+    
+    <!-- Screen brightness when dozing. -->
+    <integer name="config_screenBrightnessDoze">17</integer>
 
 </resources>


### PR DESCRIPTION
This feature was present in original Motorola 5.0 firmware. However, still missing in Cyanogenmod.
